### PR TITLE
fix(5414): Add cxx20 deprecation silence patch

### DIFF
--- a/patches/src/build/README.md
+++ b/patches/src/build/README.md
@@ -1,0 +1,7 @@
+## Build patches
+
+### silence-cxx20-deprecations
+
+> Needed since 5414.
+
+This squelches MSVCs complaints about using deprecated APIs.

--- a/patches/src/build/silence-cxx20-deprecations.patch
+++ b/patches/src/build/silence-cxx20-deprecations.patch
@@ -1,0 +1,12 @@
+diff --git a/config/win/BUILD.gn b/config/win/BUILD.gn
+index a5075393b..bed689e86 100644
+--- a/config/win/BUILD.gn
++++ b/config/win/BUILD.gn
+@@ -230,6 +230,7 @@ config("runtime_library") {
+     "_CRT_RAND_S",
+     "_CRT_SECURE_NO_DEPRECATE",
+     "_SCL_SECURE_NO_DEPRECATE",
++    "_SILENCE_ALL_CXX20_DEPRECATION_WARNINGS"
+   ]
+ 
+   # Defines that set up the Windows SDK.


### PR DESCRIPTION
Adds a patch to silcence MSVC warnings about deprecated CXX20 APIs.